### PR TITLE
Skip grammars with no matching patterns

### DIFF
--- a/lib/symbol-generator.coffee
+++ b/lib/symbol-generator.coffee
@@ -27,7 +27,7 @@ module.exports = (path, grammar, text) ->
     offset = 0
     prev = null
     for token in tokens
-      if nextIsSymbol or issymbol(token)
+      if nextIsSymbol or isSymbol(token)
         nextIsSymbol = false
 
         symbol = cleanSymbol(token)
@@ -36,7 +36,7 @@ module.exports = (path, grammar, text) ->
             symbols.push({ name: token.value, path: path, position: new Point(lineno, offset) })
             prev = token
 
-      nextIsSymbol = isbefore(token)
+      nextIsSymbol = isBefore(token)
 
       offset += token.value.length
 
@@ -47,7 +47,7 @@ cleanSymbol = (token) ->
   name = token.value.trim().replace(/"/g, '')
   name || null
 
-issymbol = (token) ->
+isSymbol = (token) ->
   # I'm a little unclear about this :\ so this might be much easier than
   # I've made it out to be.  If we really can use a single regular expression we can
   # switch to array.some() and eliminate this method all together
@@ -57,7 +57,7 @@ issymbol = (token) ->
         return true
   return false
 
-isbefore = (token) ->
+isBefore = (token) ->
   # Does this token indicate that the following token is a symbol?
   if token.value.trim().length and token.scopes
     for scope in token.scopes
@@ -74,7 +74,6 @@ mergeAdjacent = (prevToken, thisToken, symbols, offset) ->
   #
   # Returns true if the two symbols are adjacent and will merge `thisToken` into the
   # previous symbol.  Return false if thisToken is not adjacent to the previous symbol.
-
   if offset and prevToken
     prevSymbol = symbols[symbols.length-1]
     if offset is prevSymbol.position.column + prevToken.value.length

--- a/lib/symbol-generator.coffee
+++ b/lib/symbol-generator.coffee
@@ -1,5 +1,6 @@
 {Point} = require 'atom'
 patterns = require './symbol-pattern-definitions'
+logToConsole = atom.config.get('goto.logToConsole') ? false
 
 module.exports = (path, grammar, text) ->
   lines = grammar.tokenizeLines(text)
@@ -53,7 +54,7 @@ isBefore = (token) ->
   # Does this token indicate that the following token is a symbol?
   if token.value.trim().length and token.scopes
     for scope in token.scopes
-      console.log('checking', scope, '=', patterns.before.test(scope))
+      console.log('checking', scope, '=', patterns.before.test(scope)) if logToConsole
       if patterns.before.test(scope)
         return true
   return false

--- a/lib/symbol-index.coffee
+++ b/lib/symbol-index.coffee
@@ -218,8 +218,8 @@ class SymbolIndex
     base = path.basename(filePath)
     ext = path.extname(base)
 
-    # files with this extensions are known not to have a grammar.
-    if isFile and @skipGrammars[ext]?
+    # Files of this type are known not to have a grammar
+    if isFile and @skipGrammars[ext]
       console.log('GOTO: ignore/grammar', filePath) if @logToConsole
       return false
 

--- a/lib/symbol-index.coffee
+++ b/lib/symbol-index.coffee
@@ -162,8 +162,7 @@ class SymbolIndex
     path.extname(fqn) || path.parse(fqn).base
 
   processDirectory: (dirPath) ->
-    if @logToConsole
-      console.log('GOTO: directory', dirPath)
+    console.log('GOTO: directory', dirPath) if @logToConsole
 
     entries = fs.readdirSync(dirPath)
     dirs = []

--- a/lib/symbol-index.coffee
+++ b/lib/symbol-index.coffee
@@ -4,6 +4,7 @@ path = require 'path'
 _ = require 'underscore'
 minimatch = require 'minimatch'
 generate = require './symbol-generator'
+patterns = require './symbol-pattern-definitions'
 utils = require './symbol-utils'
 {CompositeDisposable} = require 'atom'
 
@@ -43,7 +44,7 @@ class SymbolIndex
     @moreIgnoredNames = atom.config.get('goto.moreIgnoredNames') ? ''
     @moreIgnoredNames = (n for n in @moreIgnoredNames.split(/[, \t]+/) when n?.length)
 
-    @noGrammar = {}
+    @skipGrammars = {}
     # File extensions that we've found have no grammar.  There are probably a lot of files
     # such as *.png that we don't have grammars for.  Instead of hardcoding them we'll record
     # them on the fly.  We'll clear this when we rescan directories.
@@ -116,7 +117,7 @@ class SymbolIndex
     for root in @roots
       @processDirectory(root.path)
     @rescanDirectories = false
-    console.log('No Grammar:', Object.keys(@noGrammar)) if @logToConsole
+    console.log('No Grammar:', Object.keys(@skipGrammars)) if @logToConsole
 
   gotoDeclaration: ->
     editor = atom.workspace.getActiveTextEditor()
@@ -181,10 +182,34 @@ class SymbolIndex
     console.log('GOTO: file', fqn) if @logToConsole
     text = fs.readFileSync(fqn, { encoding: 'utf8' })
     grammar = atom.grammars.selectGrammar(fqn, text)
-    if grammar?.scopeName isnt 'text.plain.null-grammar'
-      @entries[fqn] = generate(fqn, grammar, text)
-    else
-      @noGrammar[path.extname(fqn)] = true
+    # If no extension, use the filename as ext (e.g. .gitignore)
+    ext = path.extname(fqn) || path.parse(fqn).base
+    isSkipGrammar = @skipGrammars[ext]
+    if not grammar
+      return
+
+    #debugger
+    if not isSkipGrammar
+      if isSkipGrammar is undefined
+        # Is it a null grammar or there are no patterns that could match
+        if grammar.scopeName is 'text.plain.null-grammar' or not grammar.rawPatterns
+          isSkipGrammar = true
+        else
+          # Check rawPatterns and rawPatterns.captures for any match
+          isPatternMatch = grammar.rawPatterns.some((pattern) ->
+            isMatch = patterns.symbol.test(pattern.name)
+            if not isMatch and pattern.captures
+              # Check captures, which is an optional object (not an array)
+              for i, capture of pattern.captures
+                if isMatch = patterns.symbol.test(capture.name)
+                  break
+            isMatch
+          )
+          isSkipGrammar = not isPatternMatch
+      if isSkipGrammar is false
+        @entries[fqn] = generate(fqn, grammar, text)
+
+    @skipGrammars[ext] = isSkipGrammar
 
   keepPath: (filePath, isFile = true) ->
     # Should we keep this path in @entries?  It is not kept if it is excluded by the
@@ -194,7 +219,7 @@ class SymbolIndex
     ext = path.extname(base)
 
     # files with this extensions are known not to have a grammar.
-    if isFile and @noGrammar[ext]?
+    if isFile and @skipGrammars[ext]?
       console.log('GOTO: ignore/grammar', filePath) if @logToConsole
       return false
 

--- a/lib/symbol-pattern-definitions.coffee
+++ b/lib/symbol-pattern-definitions.coffee
@@ -1,0 +1,21 @@
+# Matching grammar scope names
+# I'm expecting this to grow a lot.  We'll also need configuration
+# that can be added to dynamically, I think.
+symbol = /// ^ (
+    entity.name.type.class
+  | entity.name.function
+  | entity.other.attribute-name.class
+) ///
+
+# Grammar scope name negations
+# More specific negations will override less specific matches
+notSymbol = /// ^ (
+) ///
+
+# A simplistic regexp that is used to match the item immediately following.  I'll eventually
+# need something a bit more complex.
+before =  /// ^ (
+  meta.rspec.behaviour
+) ///
+
+module.exports = { symbol, notSymbol, before }


### PR DESCRIPTION
Add logic to the process of identifying what file types should be checked to see if the file type’s grammar includes anything that matches our symbol patterns. Should help performance in larger projects, where many more files can be skipped. Resolves #3