### PR TITLE
Issue #38 - use config-schema format to expose settings in latest Atom version

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -4,10 +4,19 @@ GotoView = require('./goto-view')
 
 module.exports =
 
-  configDefaults:
-    logToConsole: false
-    moreIgnoredNames: ''
-    autoScroll: true
+  config:
+    logToConsole:
+      default: false
+      type: 'boolean'
+      description: 'Enable debug information logging for goto commands'
+    moreIgnoredNames:
+      default: ''
+      type: 'string'
+      description: 'Whitespace- or comma-separated list of globs for files that goto should skip. These files are in addition to those specified in the core.ignoredNames setting'
+    autoScroll:
+      default: true
+      type: 'boolean'
+      description: 'Disable this option to prevent goto from restoring your selection back to your original cursor position after cancelling a goto method'
 
   index: null
   gotoView: null

--- a/lib/symbol-index.coffee
+++ b/lib/symbol-index.coffee
@@ -39,8 +39,8 @@ class SymbolIndex
     if typeof @ignoredNames is 'string'
       @ignoredNames = [ ignoredNames ]
 
-    @logToConsole = atom.config.get('goto.logToConsole') ? false
-    @moreIgnoredNames = atom.config.get('goto.moreIgnoredNames') ? ''
+    @logToConsole = atom.config.get('goto.logToConsole')
+    @moreIgnoredNames = atom.config.get('goto.moreIgnoredNames')
     @moreIgnoredNames = (n for n in @moreIgnoredNames.split(/[, \t]+/) when n?.length)
 
     @noGrammar = {}
@@ -68,7 +68,7 @@ class SymbolIndex
       @invalidate()
 
     atom.config.observe 'goto.moreIgnoredNames', =>
-      @moreIgnoredNames = atom.config.get('goto.moreIgnoredNames') ? ''
+      @moreIgnoredNames = atom.config.get('goto.moreIgnoredNames')
       @moreIgnoredNames = (n for n in @moreIgnoredNames.split(/[, \t]+/) when n?.length)
       @invalidate()
 


### PR DESCRIPTION
Replaced the current settings with the config-schema settings recommended
by Atom. This makes sure that they are exposed, adds a helpful description,
and defaults that can now be removed from within the code.

Removed places where null coalescing operators were being used to provide
defaults for goto configuration variables. This is now being provided within the
setting definition itself.
