### PR TITLE
Multiple duplicate issues fixed - use fs-plus for directory traversal to fix symlink issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "underscore": "~1.6.0",
+    "fs-plus": "^2.8.1",
     "minimatch": "0.2.14",
     "atom-space-pen-views": "^2.0.3"
   }


### PR DESCRIPTION
Use fs-plus for directory traversal to fix symlink issues. Should close issues #74, #71, #67, #64, and #23.  I've added a repo at mshenfield/goto-symlink-tests which contains mostly broken symlinks.
- `git clone https://github.com/mshenfield/goto-symlink-tests`
-  `apm link`your working goto directory to your atom packages directory
-  open goto-symlink-tests with goto master checked out
- run Cmd/Ctrl+Shift+R. You should observe an error
- checkout the `use-fs-plus-traverse-tree-sync-to-read-in-files` branch
- reload Atom (View > Reload)
- run Cmd/Ctrl+Shift+R on goto-symlink-tests. No errors occur

This also removes unnecessary complexity from the project and opens
up the possibility of switching to asynchronous, non-blocking
directory traversal without a method name change and a callback.
