### PR TITLE
Multiple duplicate issues fixed - use fs-plus for directory traversal to fix symlink issues

### DIFF
--- a/lib/symbol-index.coffee
+++ b/lib/symbol-index.coffee
@@ -1,7 +1,6 @@
 
 fs = require 'fs-plus'
 path = require 'path'
-_ = require 'underscore'
 minimatch = require 'minimatch'
 generate = require './symbol-generator'
 utils = require './symbol-utils'
@@ -177,11 +176,11 @@ class SymbolIndex
         console.log('GOTO: ignore/core', filePath) if @logToConsole
         return false
 
-    if _.contains(@ignoredNames, base)
+    if @ignoredNames.includes(base)
       console.log('GOTO: ignore/core', filePath) if @logToConsole
       return false
 
-    if ext and _.contains(@ignoredNames, '*#{ext}')
+    if ext and @ignoredNames.includes('*#{ext}')
       console.log('GOTO: ignore/core', filePath) if @logToConsole
       return false
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,8 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "underscore": "~1.6.0",
-    "fs-plus": "^2.8.1",
-    "minimatch": "0.2.14",
-    "atom-space-pen-views": "^2.0.3"
+    "fs-plus": "^2.9.3",
+    "minimatch": "^3.0.3",
+    "atom-space-pen-views": "^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "underscore": "~1.6.0",
+    "fs-plus": "^2.8.1",
     "minimatch": "0.2.14",
     "atom-space-pen-views": "^2.0.3"
   }


### PR DESCRIPTION
Resolved conflicts and updated deps with #79. Description from the origin PR:

------

Use fs-plus for directory traversal to fix symlink issues. Should close issues #74, #71, #67, #64, and #23.  I've added a repo at mshenfield/goto-symlink-tests which contains mostly broken symlinks.
- `git clone https://github.com/mshenfield/goto-symlink-tests`
-  `apm link`your working goto directory to your atom packages directory
-  open goto-symlink-tests with goto master checked out
- run Cmd/Ctrl+Shift+R. You should observe an error
- checkout the `use-fs-plus-traverse-tree-sync-to-read-in-files` branch
- reload Atom (View > Reload)
- run Cmd/Ctrl+Shift+R on goto-symlink-tests. No errors occur

This also removes unnecessary complexity from the project and opens
up the possibility of switching to asynchronous, non-blocking
directory traversal without a method name change and a callback.
