### PR TITLE
Skip processing of ignored files during rebuild

### DIFF
--- a/lib/symbol-index.coffee
+++ b/lib/symbol-index.coffee
@@ -110,7 +110,7 @@ class SymbolIndex
     for root in atom.project.getDirectories()
       fs.traverseTreeSync(
         root.path,
-        (filePath) => @processFile filePath,
+        (filePath) => @processFile filePath if @keepPath filePath,
         (filePath) => @keepPath filePath
       )
     @rescanDirectories = false
@@ -150,8 +150,6 @@ class SymbolIndex
           matches.push(symbol)
 
   processFile: (fqn) ->
-    if not @keepPath(fqn)
-      return
     console.log('GOTO: file', fqn) if @logToConsole
     text = fs.readFileSync(fqn, { encoding: 'utf8' })
     grammar = atom.grammars.selectGrammar(fqn, text)

--- a/lib/symbol-index.coffee
+++ b/lib/symbol-index.coffee
@@ -103,7 +103,7 @@ class SymbolIndex
       @rebuild()
     else
       for fqn, symbols of @entries
-        if symbols is null and @keepPath(fqn)
+        if symbols is null
           @processFile(fqn)
 
   rebuild: ->

--- a/lib/symbol-index.coffee
+++ b/lib/symbol-index.coffee
@@ -150,6 +150,8 @@ class SymbolIndex
           matches.push(symbol)
 
   processFile: (fqn) ->
+    if not @keepPath(fqn)
+      return
     console.log('GOTO: file', fqn) if @logToConsole
     text = fs.readFileSync(fqn, { encoding: 'utf8' })
     grammar = atom.grammars.selectGrammar(fqn, text)


### PR DESCRIPTION
This pull request fixes #99 and possibly other problems caused by processing "ignored" project files. In my case, a very large file apparently overflowed the buffer and crashed the project indexing.

The problem happens in `rebuild`: `traverseTreeSync` only checks `keepPath` on directories, not files, and so ignored files can still be processed.